### PR TITLE
feat: add a new function for calculating markup based on item rarity and zone

### DIFF
--- a/Items/ItemsDatabase.cs
+++ b/Items/ItemsDatabase.cs
@@ -16,12 +16,14 @@ namespace StarSmuggler
                 new Item("holochips", "Holochips", "Cheap holographic entertainment modules.", ItemRarity.Common, 25),
                 new Item("plasteel_scraps", "Plasteel Scraps", "Lightweight and durable construction material.", ItemRarity.Common, 35),
                 new Item("medigel", "Medigel", "Basic medical gel for treating minor injuries.", ItemRarity.Common, 50),
+                
                 new Item("neurodust", "Neurodust", "Hallucinogenic powder with precognition effects.", ItemRarity.MidTier, 150),
                 new Item("void_silk", "Void Silk", "Luxury zero-G fabric harvested from orbital spiders.", ItemRarity.MidTier, 220),
                 new Item("quantum_seeds", "Quantum Seeds", "Encrypted gene seeds for forbidden crops.", ItemRarity.MidTier, 280),
                 new Item("neural_implants", "Neural Implants", "Black-market dream recorders and enhancers.", ItemRarity.MidTier, 320),
                 new Item("grav_crystals", "Grav Crystals", "Crystals used in advanced anti-gravity tech.", ItemRarity.MidTier, 200),
                 new Item("biofoam", "Biofoam", "Advanced healing foam for emergency surgeries.", ItemRarity.MidTier, 260),
+                
                 new Item("enceladite", "Enceladite", "Highly unstable energy ore from Enceladus.", ItemRarity.Exotic, 800),
                 new Item("cryobloom_spores", "Cryobloom Spores", "Bioluminescent Europa spores with medicinal uses.", ItemRarity.Exotic, 950),
                 new Item("temporal_relics", "Temporal Relics", "Artifacts with rumored time-warping properties.", ItemRarity.Exotic, 1200),


### PR DESCRIPTION
This change adds an additional markup for items based on their rarity and the zone of the current port. This should create better margins for trading on. It also reduces the cost of travel between ports and increases the event chance to 30%